### PR TITLE
Add require('core-js/stable') to InnovationGame

### DIFF
--- a/bgio2/src/InnovationGame.js
+++ b/bgio2/src/InnovationGame.js
@@ -1,6 +1,8 @@
 import {INVALID_MOVE} from 'boardgame.io/core';
 import {generateDecks, stackablesTable} from './InnovationData';
 
+require('core-js/stable')
+
 export const Innovation = {
     name: 'innovation',
     minPlayers: 2,


### PR DESCRIPTION
I'm going to be hoenst, I don't know why this is required, since we seem
to be on the same node version, but this seems to be a workaround
according to:

https://stackoverflow.com/questions/55530690/javascript-flatmap-method-over-array-flatmap-is-not-a-function

A truly glorious first commit.